### PR TITLE
serialandFilter.pyのデータ取得ロジックを修正し、全アンカーの情報を確実に取り込む

### DIFF
--- a/tk_uwb_ekf/launch/ekf_with_serial.launch.py
+++ b/tk_uwb_ekf/launch/ekf_with_serial.launch.py
@@ -15,7 +15,7 @@ def generate_launch_description():
                 {'com_port': '/dev/ttyUSB1'},
                 {'baud_rate': 3000000},
                 {'num_anchors': 3},
-                {'uwb_timeout': 0.04}, # タイマー周期(0.05s)より少し短く設定
+                {'uwb_timeout': 0.5},
                 
                 # アンカー座標
                 {'anchor_a_pos': [0.0, 5.0]}, # TWR0

--- a/tk_uwb_ekf/launch/ekf_with_serial.launch.py
+++ b/tk_uwb_ekf/launch/ekf_with_serial.launch.py
@@ -5,22 +5,19 @@ def generate_launch_description():
     return LaunchDescription([
         Node(
             package='tk_uwb_ekf',
-            # 実行するスクリプト名を変更
             executable='uwb_ekf_node',
             name='uwb_ekf_node',
             output='screen',
             emulate_tty=True, # シリアルからのprint出力をコンソールに表示するために推奨
             parameters=[
-                # シリアル通信パラメータ
                 {'com_port': '/dev/ttyUSB1'},
                 {'baud_rate': 3000000},
                 {'num_anchors': 3},
-                {'uwb_timeout': 0.5},
+                {'uwb_timeout': 0.05},
                 
-                # アンカー座標
-                {'anchor_a_pos': [0.0, 5.0]}, # TWR0
-                {'anchor_b_pos': [5.0, 5.0]}, # TWR1
-                {'anchor_c_pos': [2.5, 0.0]}, # TWR2
+                {'anchor_a_pos': [0.0, 0.0]},    # TWR0 (Anchor 0)
+                {'anchor_b_pos': [8.4, 0.0]},    # TWR1 (Anchor 1)
+                {'anchor_c_pos': [7.29, 4.57]},  # TWR2 (Anchor 2)
             ]
         )
     ])

--- a/tk_uwb_ekf/tk_uwb_ekf/serialandFilter.py
+++ b/tk_uwb_ekf/tk_uwb_ekf/serialandFilter.py
@@ -56,7 +56,7 @@ class SerialFilter:
             self.ser.close()
             print(f"🥳{self.com_port}から接続解除しました。")
 
-    def read_anchor_data_snapshot(self, timeout: float = 0.5) -> Optional[Dict[str, Any]]:
+    def read_anchor_data_snapshot(self, timeout: float = 0.05) -> Optional[Dict[str, Any]]:
         if not self.ser or not self.ser.is_open:
             print("エラー: シリアルポートが開いていません。")
             return None
@@ -102,7 +102,7 @@ class SerialFilter:
                         twr_id = int(elevation_match.group(1))
                         elevation = float(elevation_match.group(2))
                         collected_data.setdefault(twr_id, {})["elevation_angle"] = round(elevation, 2)
-                        break
+                        continue
                     
                     
 
@@ -127,7 +127,7 @@ class SerialFilter:
 
 # This block is for standalone testing of this module
 if __name__ == "__main__":
-    uwb_filter = SerialFilter(com_port="COM7", num_anchors=3)
+    uwb_filter = SerialFilter(com_port="/dev/ttyUSB0", num_anchors=3)
     if not uwb_filter.connect_serial():
         print("プログラムを終了します")
         exit()
@@ -135,7 +135,7 @@ if __name__ == "__main__":
     try:
         print("😀データ収集を開始する")
         while True:
-            anchor_data = uwb_filter.read_anchor_data_snapshot(timeout=0.5)
+            anchor_data = uwb_filter.read_anchor_data_snapshot(timeout=0.05)
             print(f"\n--- {time.ctime()} ---")
             if anchor_data:
                 pprint.pprint(anchor_data)

--- a/tk_uwb_ekf/tk_uwb_ekf/serialandFilter.py
+++ b/tk_uwb_ekf/tk_uwb_ekf/serialandFilter.py
@@ -102,7 +102,9 @@ class SerialFilter:
                         twr_id = int(elevation_match.group(1))
                         elevation = float(elevation_match.group(2))
                         collected_data.setdefault(twr_id, {})["elevation_angle"] = round(elevation, 2)
-                        continue
+                        break
+                    
+                    
 
             except Exception as e:
                 print(f"データパース中にエラーが発生しました: {e}")
@@ -125,7 +127,7 @@ class SerialFilter:
 
 # This block is for standalone testing of this module
 if __name__ == "__main__":
-    uwb_filter = SerialFilter(com_port="/dev/ttyUSB0", num_anchors=3)
+    uwb_filter = SerialFilter(com_port="COM7", num_anchors=3)
     if not uwb_filter.connect_serial():
         print("プログラムを終了します")
         exit()

--- a/tk_uwb_ekf/tk_uwb_ekf/serialandFilter.py
+++ b/tk_uwb_ekf/tk_uwb_ekf/serialandFilter.py
@@ -103,8 +103,6 @@ class SerialFilter:
                         elevation = float(elevation_match.group(2))
                         collected_data.setdefault(twr_id, {})["elevation_angle"] = round(elevation, 2)
                         continue
-                    
-                    
 
             except Exception as e:
                 print(f"データパース中にエラーが発生しました: {e}")

--- a/tk_uwb_ekf/tk_uwb_ekf/test.py
+++ b/tk_uwb_ekf/tk_uwb_ekf/test.py
@@ -1,9 +1,0 @@
-count = 10
-for a in range(2,count):
-    
-    if (a % 13 == 0):
-        print(a)
-        continue
-
-    print("あっは")
-    break

--- a/tk_uwb_ekf/tk_uwb_ekf/test.py
+++ b/tk_uwb_ekf/tk_uwb_ekf/test.py
@@ -1,0 +1,9 @@
+count = 10
+for a in range(2,count):
+    
+    if (a % 13 == 0):
+        print(a)
+        continue
+
+    print("あっは")
+    break

--- a/tk_uwb_ekf/tk_uwb_ekf/uwb_ekf_node.py
+++ b/tk_uwb_ekf/tk_uwb_ekf/uwb_ekf_node.py
@@ -5,118 +5,101 @@ import numpy as np
 import sys
 
 from nav_msgs.msg import Odometry
+from sensor_msgs.msg import Imu
 from geometry_msgs.msg import TransformStamped
 from tf2_ros import TransformBroadcaster
 from tf_transformations import quaternion_from_euler
 
 from filterpy.kalman import ExtendedKalmanFilter
+import math 
 
-from .serial_filter import SerialFilter
+from .serialandFilter import SerialFilter
 
-class UwbSlamEkfNode(Node):
+class UwbEkfNode(Node):
     def __init__(self):
-        super().__init__('uwb_slam_ekf_node')
+        super().__init__('uwb_ekf_node')
 
-        # --- パラメータ宣言 ---
+        # ---変更点: シリアル通信用のパラメータを追加---
         self.declare_parameter('com_port', '/dev/ttyUSB1')
         self.declare_parameter('baud_rate', 3000000)
-        self.declare_parameter('uwb_timeout', 0.1)
+        self.declare_parameter('num_anchors', 3)
+        self.declare_parameter('uwb_timeout', 0.05) # UWBデータ読み取りタイムアウト
 
-        # アンカーの初期位置をパラメータから取得
-        # これらはフィルターの初期推測値として使用される
         self.declare_parameter('anchor_a_pos', [0.0, 5.0])
         self.declare_parameter('anchor_b_pos', [5.0, 5.0])
         self.declare_parameter('anchor_c_pos', [2.5, 0.0])
         
-        # --- パラメータ読み込み ---
+        # ---変更点: パラメータを取得---
         com_port = self.get_parameter('com_port').get_parameter_value().string_value
         baud_rate = self.get_parameter('baud_rate').get_parameter_value().integer_value
+        num_anchors = self.get_parameter('num_anchors').get_parameter_value().integer_value
         self.uwb_timeout = self.get_parameter('uwb_timeout').get_parameter_value().double_value
         
-        initial_anchor_pos = [
-            self.get_parameter('anchor_a_pos').get_parameter_value().double_array_value,
-            self.get_parameter('anchor_b_pos').get_parameter_value().double_array_value,
-            self.get_parameter('anchor_c_pos').get_parameter_value().double_array_value,
-        ]
-        self.get_logger().info(f"Initial anchor positions (guess): {initial_anchor_pos}")
+        # アンカーの座標をパラメータから取得
+        # TWR0 -> a, TWR1 -> b, ... のようにマッピング
+        self.anchor_positions = {
+            'a': self.get_parameter('anchor_a_pos').get_parameter_value().double_array_value,
+            'b': self.get_parameter('anchor_b_pos').get_parameter_value().double_array_value,
+            'c': self.get_parameter('anchor_c_pos').get_parameter_value().double_array_value,
+        }
+        self.anchor_map = {0: 'a', 1: 'b', 2: 'c'}
+        self.get_logger().info(f"Anchor positions: {self.anchor_positions}")
 
-        # --- EKFの状態空間モデル定義 ---
-        self.ROBOT_STATE_DIM = 5  # x, y, theta, v, w
-        self.ANCHOR_STATE_DIM = 2 # x, y
-        self.NUM_ANCHORS = 3
-        dim_x = self.ROBOT_STATE_DIM + self.NUM_ANCHORS * self.ANCHOR_STATE_DIM # 5 + 3*2 = 11
-
-        self.ekf = ExtendedKalmanFilter(dim_x=dim_x, dim_z=1)
-
-        # --- 状態ベクトル x の初期化 ---
-        # [robot_x, robot_y, robot_theta, v, w, a_x, a_y, b_x, b_y, c_x, c_y]
-        initial_robot_state = np.zeros(self.ROBOT_STATE_DIM)
-        initial_anchor_states = np.array(initial_anchor_pos).flatten()
-        self.ekf.x = np.concatenate([initial_robot_state, initial_anchor_states]).reshape(dim_x, 1)
-
-        # --- 共分散行列 P の初期化 ---
-        # ロボットの状態の不確かさは小さく設定
-        robot_P = np.diag([0.1**2, 0.1**2, np.deg2rad(1.0)**2, 0.1**2, np.deg2rad(1.0)**2])
-        # ★重要★ アンカーの初期位置の不確かさは非常に大きく設定
-        # これによりフィルターはUWB測定に基づいてアンカー位置を積極的に調整する
-        anchor_P = np.diag(np.tile([100.0**2, 100.0**2], self.NUM_ANCHORS))
-        # ブロック行列としてPを組み立てる
-        self.ekf.P = np.block([
-            [robot_P, np.zeros((self.ROBOT_STATE_DIM, self.NUM_ANCHORS * self.ANCHOR_STATE_DIM))],
-            [np.zeros((self.NUM_ANCHORS * self.ANCHOR_STATE_DIM, self.ROBOT_STATE_DIM)), anchor_P]
-        ])
-
-        # --- プロセスノイズ Q の設定 ---
-        # ノイズはロボットの状態(特に速度)にのみ影響し、アンカーは静的と仮定
-        self.ekf.Q = np.zeros((dim_x, dim_x))
-        q_robot = np.diag([0.01**2, 0.01**2, np.deg2rad(0.1)**2, 0.1**2, np.deg2rad(1)**2])
-        self.ekf.Q[0:self.ROBOT_STATE_DIM, 0:self.ROBOT_STATE_DIM] = q_robot
-
-        # --- 測定ノイズ R の設定 ---
-        self.R_uwb = np.diag([0.1**2]) # UWBの測定誤差分散 (標準偏差10cmを仮定)
-
-        # --- シリアル通信のセットアップ ---
-        self.uwb_reader = SerialFilter(com_port, baud_rate, self.NUM_ANCHORS)
+        # ---変更点: SerialFilterをインスタンス化し、接続---
+        self.uwb_reader = SerialFilter(com_port, baud_rate, num_anchors)
         if not self.uwb_reader.connect_serial():
             self.get_logger().error("シリアルポートへの接続に失敗しました。ノードを終了します。")
+            # rclpy.shutdown()を直接呼ぶのは推奨されないため、タイマーを止めるなどして終了を促す
+            # ここではシンプルにsys.exit()を使用（本来はよりクリーンな終了処理が望ましい）
             sys.exit(1)
 
-        # --- ROS 2通信インターフェース ---
+        # --- EKFの初期設定 (変更なし) ---
+        self.ekf = ExtendedKalmanFilter(dim_x=5, dim_z=1)
+        self.ekf.x = np.array([[0.0, 0.0, 0.0, 0.0, 0.0]]).T
+        self.ekf.P = np.diag([1.0, 1.0, np.pi, 1.0, 0.5])
+        self.ekf.Q = np.diag([0.01, 0.01, 0.01, 0.1, 0.1])
+        self.R_uwb = np.diag([0.2**2]) 
+
         self.last_time = self.get_clock().now()
         self.latest_odom = None
+        self.latest_imu = None
+
+        # Subscribers (UWB関連は削除)
         self.odom_sub = self.create_subscription(Odometry, '/odom', self.odom_callback, 10)
+        self.imu_sub = self.create_subscription(Imu, '/imu/data', self.imu_callback, 10)
+
+        # Publishers
         self.filtered_odom_pub = self.create_publisher(Odometry, '/odometry/filtered', 10)
         self.tf_broadcaster = TransformBroadcaster(self)
-        self.timer = self.create_timer(0.5, self.timer_callback) # 20Hzでメインループを実行
 
+        # メインループタイマー (20Hz) - UWBの読み取り周期に合わせる
+        self.timer = self.create_timer(0.05, self.timer_callback)
+
+    # ---変更点: ノード終了時にシリアルを切断---
     def destroy_node(self):
         self.get_logger().info("ノードをシャットダウンします。")
         self.uwb_reader.disconnect_serial()
         super().destroy_node()
 
+    # --- コールバック関数 ---
     def odom_callback(self, msg):
         self.latest_odom = msg
+
+    def imu_callback(self, msg):
+        self.latest_imu = msg
         
-    # --- U-SLAM EKFの計算モデル ---
+    # --- EKFの計算モデル (変更なし) ---
     def state_transition_function(self, x, dt):
-        """状態遷移関数 f(x) - アンカーの位置は変化しない"""
         x_new = np.copy(x)
         theta, v, w = x[2, 0], x[3, 0], x[4, 0]
-        
-        # ロボットの状態のみ更新
         x_new[0] = x[0, 0] + v * dt * np.cos(theta)
         x_new[1] = x[1, 0] + v * dt * np.sin(theta)
         x_new[2] = x[2, 0] + w * dt
-        
-        # アンカーの状態は静的なので変化しない (x_new[5:] = x[5:])
         return x_new
 
     def state_transition_jacobian(self, x, dt):
-        """状態遷移ヤコビ行列 F - アンカーの状態遷移は単位行列"""
-        F = np.eye(self.ekf.dim_x) # まずは単位行列で初期化
         theta, v = x[2, 0], x[3, 0]
-        
-        # ロボットに対応する部分のみを更新
+        F = np.eye(5)
         F[0, 2] = -v * dt * np.sin(theta)
         F[0, 3] = dt * np.cos(theta)
         F[1, 2] = v * dt * np.cos(theta)
@@ -124,77 +107,66 @@ class UwbSlamEkfNode(Node):
         F[2, 4] = dt
         return F
 
-    def h_uslam(self, x, anchor_index):
-        """測定関数 h(x) - ロボットと指定アンカー間の距離"""
-        robot_pos = x[0:2]
-        anchor_start_idx = self.ROBOT_STATE_DIM + anchor_index * self.ANCHOR_STATE_DIM
-        anchor_pos = x[anchor_start_idx : anchor_start_idx + self.ANCHOR_STATE_DIM]
-        
-        return np.array([[np.linalg.norm(robot_pos - anchor_pos)]])
+    def h_uwb(self, x, anchor_pos): #3平方の定理を行っている。
+        dx = x[0, 0] - anchor_pos[0]
+        dy = x[1, 0] - anchor_pos[1]
+        return np.array([[np.sqrt(dx**2 + dy**2)]])
 
-    def H_uslam(self, x, anchor_index):
-        """測定ヤコビ行列 H - h(x)を状態ベクトルxで偏微分"""
-        H = np.zeros((1, self.ekf.dim_x))
-        robot_pos = x[0:2].flatten()
-        anchor_start_idx = self.ROBOT_STATE_DIM + anchor_index * self.ANCHOR_STATE_DIM
-        anchor_pos = x[anchor_start_idx : anchor_start_idx + self.ANCHOR_STATE_DIM].flatten()
-        
-        delta = robot_pos - anchor_pos
-        dist = np.linalg.norm(delta)
-        if dist < 1e-6: return H
-
-        # ロボット位置(x, y)に関する偏微分
-        H[0, 0] = delta[0] / dist
-        H[0, 1] = delta[1] / dist
-        
-        # 対応するアンカー位置(x, y)に関する偏微分
-        H[0, anchor_start_idx] = -delta[0] / dist
-        H[0, anchor_start_idx + 1] = -delta[1] / dist
-        
+    def H_uwb(self, x, anchor_pos):
+        dx = x[0, 0] - anchor_pos[0]
+        dy = x[1, 0] - anchor_pos[1]
+        dist = np.sqrt(dx**2 + dy**2)
+        if dist < 1e-6: return np.zeros((1, 5))
+        H = np.zeros((1, 5)); H[0, 0] = dx / dist; H[0, 1] = dy / dist
         return H
 
-    # --- メインループ ---
     def timer_callback(self):
         current_time = self.get_clock().now()
         dt = (current_time - self.last_time).nanoseconds / 1e9
         self.last_time = current_time
-        if dt <= 0: return
 
-        # --- 予測(Predict)ステップ ---
+        if dt <= 0:
+            return
+
         if self.latest_odom:
             self.ekf.x[3,0] = self.latest_odom.twist.twist.linear.x
             self.ekf.x[4,0] = self.latest_odom.twist.twist.angular.z
         
         F = self.state_transition_jacobian(self.ekf.x, dt)
+        
         self.ekf.P = F @ self.ekf.P @ F.T + self.ekf.Q
-        self.ekf.x = self.state_transition_function(self.ekf.x, dt)
+        self.ekf.x = self.state_transition_function(self.ekf.x, dt) # ホイールお度目取りの情報をもとに、「次はここにいるはずだ」という計算だけが行われる。
 
-        # --- 更新(Update)ステップ ---
         anchor_data = self.uwb_reader.read_anchor_data_snapshot(timeout=self.uwb_timeout)
+        
+        # ここでAnchorData取得できたら！！！
         if anchor_data:
             for twr_id_str, data in anchor_data.items():
-                if data and data['nlos_los'] == 'LOS':
-                    twr_index = int(twr_id_str.replace('TWR', ''))
-                    z = np.array([[data['distance']]])
+                if data: # データがNoneでないか確認
+                    twr_index = int(twr_id_str.replace('TWR', '')) 
                     
-                    self.ekf.update(z, HJacobian=self.H_uslam, Hx=self.h_uslam, R=self.R_uwb,
-                                    args=(twr_index,), hx_args=(twr_index,))
+                    if data['nlos_los'] == 'LOS':
+                        anchor_id = self.anchor_map.get(twr_index)
+                        if anchor_id:
+                            anchor_pos = self.anchor_positions[anchor_id]
+                            z = np.array([[data['distance']]])
+                            
+                            self.ekf.update(z, HJacobian=self.H_uwb, Hx=self.h_uwb, R=self.R_uwb,
+                                            args=(anchor_pos,), hx_args=(anchor_pos,))
 
-        # --- 結果の出力 ---
+        # --- 結果の出力 (変更なし) ---
         self.publish_odometry(current_time)
         self.publish_tf(current_time)
         
     def publish_odometry(self, current_time):
-        """EKFの結果（ロボットの状態のみ）をOdometryとして発行"""
         odom_msg = Odometry()
-        odom_msg.header.stamp = current_time.to_msg(); odom_msg.header.frame_id = 'map'; odom_msg.child_frame_id = 'base_link'
+        odom_msg.header.stamp = current_time.to_msg(); odom_msg.header.frame_id = 'map'; odom_msg.child_frame_id = 'base_footprint'
         x, y, theta = self.ekf.x[0,0], self.ekf.x[1,0], self.ekf.x[2,0]
         odom_msg.pose.pose.position.x = x; odom_msg.pose.pose.position.y = y
-        q = quaternion_from_euler(0, 0, theta)
+        q = quaternion_from_euler(0, 0, theta - math.pi / 2)
         odom_msg.pose.pose.orientation.x = q[0]; odom_msg.pose.pose.orientation.y = q[1]; odom_msg.pose.pose.orientation.z = q[2]; odom_msg.pose.pose.orientation.w = q[3]
-        # 共分散もロボットの部分だけを抽出
-        P_pose = self.ekf.P[0:3, 0:3]; indices = [0, 1, 5] # x, y, yaw in 6x6 covariance
         odom_msg.pose.covariance = np.zeros(36)
+        P_pose = self.ekf.P[0:3, 0:3]; indices = [0, 1, 5]
         for i, row in enumerate(indices):
             for j, col in enumerate(indices): odom_msg.pose.covariance[row*6 + col] = P_pose[i, j]
         odom_msg.twist.twist.linear.x = self.ekf.x[3, 0]; odom_msg.twist.twist.angular.z = self.ekf.x[4, 0]
@@ -205,13 +177,13 @@ class UwbSlamEkfNode(Node):
         t.header.stamp = current_time.to_msg(); t.header.frame_id = 'map'; t.child_frame_id = 'base_link'
         x, y, theta = self.ekf.x[0,0], self.ekf.x[1,0], self.ekf.x[2,0]
         t.transform.translation.x = x; t.transform.translation.y = y; t.transform.translation.z = 0.0
-        q = quaternion_from_euler(0, 0, theta)
+        q = quaternion_from_euler(0, 0, theta - math.pi / 2)
         t.transform.rotation.x = q[0]; t.transform.rotation.y = q[1]; t.transform.rotation.z = q[2]; t.transform.rotation.w = q[3]
         self.tf_broadcaster.sendTransform(t)
 
 def main(args=None):
     rclpy.init(args=args)
-    node = UwbSlamEkfNode()
+    node = UwbEkfNode()
     try:
         rclpy.spin(node)
     except KeyboardInterrupt:
@@ -222,4 +194,3 @@ def main(args=None):
 
 if __name__ == '__main__':
     main()
-

--- a/tk_uwb_ekf/tk_uwb_ekf/uwb_ekf_node.py
+++ b/tk_uwb_ekf/tk_uwb_ekf/uwb_ekf_node.py
@@ -5,101 +5,118 @@ import numpy as np
 import sys
 
 from nav_msgs.msg import Odometry
-from sensor_msgs.msg import Imu
 from geometry_msgs.msg import TransformStamped
 from tf2_ros import TransformBroadcaster
 from tf_transformations import quaternion_from_euler
 
 from filterpy.kalman import ExtendedKalmanFilter
 
-# ---変更点: SerialFilterクラスをインポート---
-from .serialandFilter import SerialFilter
+from .serial_filter import SerialFilter
 
-class UwbEkfNode(Node):
+class UwbSlamEkfNode(Node):
     def __init__(self):
-        super().__init__('uwb_ekf_node')
+        super().__init__('uwb_slam_ekf_node')
 
-        # ---変更点: シリアル通信用のパラメータを追加---
+        # --- パラメータ宣言 ---
         self.declare_parameter('com_port', '/dev/ttyUSB1')
         self.declare_parameter('baud_rate', 3000000)
-        self.declare_parameter('num_anchors', 3)
-        self.declare_parameter('uwb_timeout', 0.1) # UWBデータ読み取りタイムアウト
+        self.declare_parameter('uwb_timeout', 0.1)
 
+        # アンカーの初期位置をパラメータから取得
+        # これらはフィルターの初期推測値として使用される
         self.declare_parameter('anchor_a_pos', [0.0, 5.0])
         self.declare_parameter('anchor_b_pos', [5.0, 5.0])
         self.declare_parameter('anchor_c_pos', [2.5, 0.0])
         
-        # ---変更点: パラメータを取得---
+        # --- パラメータ読み込み ---
         com_port = self.get_parameter('com_port').get_parameter_value().string_value
         baud_rate = self.get_parameter('baud_rate').get_parameter_value().integer_value
-        num_anchors = self.get_parameter('num_anchors').get_parameter_value().integer_value
         self.uwb_timeout = self.get_parameter('uwb_timeout').get_parameter_value().double_value
         
-        # アンカーの座標をパラメータから取得
-        # TWR0 -> a, TWR1 -> b, ... のようにマッピング
-        self.anchor_positions = {
-            'a': self.get_parameter('anchor_a_pos').get_parameter_value().double_array_value,
-            'b': self.get_parameter('anchor_b_pos').get_parameter_value().double_array_value,
-            'c': self.get_parameter('anchor_c_pos').get_parameter_value().double_array_value,
-        }
-        self.anchor_map = {0: 'a', 1: 'b', 2: 'c'}
-        self.get_logger().info(f"Anchor positions: {self.anchor_positions}")
+        initial_anchor_pos = [
+            self.get_parameter('anchor_a_pos').get_parameter_value().double_array_value,
+            self.get_parameter('anchor_b_pos').get_parameter_value().double_array_value,
+            self.get_parameter('anchor_c_pos').get_parameter_value().double_array_value,
+        ]
+        self.get_logger().info(f"Initial anchor positions (guess): {initial_anchor_pos}")
 
-        # ---変更点: SerialFilterをインスタンス化し、接続---
-        self.uwb_reader = SerialFilter(com_port, baud_rate, num_anchors)
+        # --- EKFの状態空間モデル定義 ---
+        self.ROBOT_STATE_DIM = 5  # x, y, theta, v, w
+        self.ANCHOR_STATE_DIM = 2 # x, y
+        self.NUM_ANCHORS = 3
+        dim_x = self.ROBOT_STATE_DIM + self.NUM_ANCHORS * self.ANCHOR_STATE_DIM # 5 + 3*2 = 11
+
+        self.ekf = ExtendedKalmanFilter(dim_x=dim_x, dim_z=1)
+
+        # --- 状態ベクトル x の初期化 ---
+        # [robot_x, robot_y, robot_theta, v, w, a_x, a_y, b_x, b_y, c_x, c_y]
+        initial_robot_state = np.zeros(self.ROBOT_STATE_DIM)
+        initial_anchor_states = np.array(initial_anchor_pos).flatten()
+        self.ekf.x = np.concatenate([initial_robot_state, initial_anchor_states]).reshape(dim_x, 1)
+
+        # --- 共分散行列 P の初期化 ---
+        # ロボットの状態の不確かさは小さく設定
+        robot_P = np.diag([0.1**2, 0.1**2, np.deg2rad(1.0)**2, 0.1**2, np.deg2rad(1.0)**2])
+        # ★重要★ アンカーの初期位置の不確かさは非常に大きく設定
+        # これによりフィルターはUWB測定に基づいてアンカー位置を積極的に調整する
+        anchor_P = np.diag(np.tile([100.0**2, 100.0**2], self.NUM_ANCHORS))
+        # ブロック行列としてPを組み立てる
+        self.ekf.P = np.block([
+            [robot_P, np.zeros((self.ROBOT_STATE_DIM, self.NUM_ANCHORS * self.ANCHOR_STATE_DIM))],
+            [np.zeros((self.NUM_ANCHORS * self.ANCHOR_STATE_DIM, self.ROBOT_STATE_DIM)), anchor_P]
+        ])
+
+        # --- プロセスノイズ Q の設定 ---
+        # ノイズはロボットの状態(特に速度)にのみ影響し、アンカーは静的と仮定
+        self.ekf.Q = np.zeros((dim_x, dim_x))
+        q_robot = np.diag([0.01**2, 0.01**2, np.deg2rad(0.1)**2, 0.1**2, np.deg2rad(1)**2])
+        self.ekf.Q[0:self.ROBOT_STATE_DIM, 0:self.ROBOT_STATE_DIM] = q_robot
+
+        # --- 測定ノイズ R の設定 ---
+        self.R_uwb = np.diag([0.1**2]) # UWBの測定誤差分散 (標準偏差10cmを仮定)
+
+        # --- シリアル通信のセットアップ ---
+        self.uwb_reader = SerialFilter(com_port, baud_rate, self.NUM_ANCHORS)
         if not self.uwb_reader.connect_serial():
             self.get_logger().error("シリアルポートへの接続に失敗しました。ノードを終了します。")
-            # rclpy.shutdown()を直接呼ぶのは推奨されないため、タイマーを止めるなどして終了を促す
-            # ここではシンプルにsys.exit()を使用（本来はよりクリーンな終了処理が望ましい）
             sys.exit(1)
 
-        # --- EKFの初期設定 (変更なし) ---
-        self.ekf = ExtendedKalmanFilter(dim_x=5, dim_z=1)
-        self.ekf.x = np.array([[0.0, 0.0, 0.0, 0.0, 0.0]]).T
-        self.ekf.P = np.diag([1.0, 1.0, np.pi, 1.0, 0.5])
-        self.ekf.Q = np.diag([0.01, 0.01, 0.01, 0.1, 0.1])
-        self.R_uwb = np.diag([0.1**2]) 
-
+        # --- ROS 2通信インターフェース ---
         self.last_time = self.get_clock().now()
         self.latest_odom = None
-        self.latest_imu = None
-
-        # Subscribers (UWB関連は削除)
         self.odom_sub = self.create_subscription(Odometry, '/odom', self.odom_callback, 10)
-        self.imu_sub = self.create_subscription(Imu, '/imu/data', self.imu_callback, 10)
-
-        # Publishers
         self.filtered_odom_pub = self.create_publisher(Odometry, '/odometry/filtered', 10)
         self.tf_broadcaster = TransformBroadcaster(self)
+        self.timer = self.create_timer(0.5, self.timer_callback) # 20Hzでメインループを実行
 
-        # メインループタイマー (20Hz) - UWBの読み取り周期に合わせる
-        self.timer = self.create_timer(0.05, self.timer_callback)
-
-    # ---変更点: ノード終了時にシリアルを切断---
     def destroy_node(self):
         self.get_logger().info("ノードをシャットダウンします。")
         self.uwb_reader.disconnect_serial()
         super().destroy_node()
 
-    # --- コールバック関数 ---
     def odom_callback(self, msg):
         self.latest_odom = msg
-
-    def imu_callback(self, msg):
-        self.latest_imu = msg
         
-    # --- EKFの計算モデル (変更なし) ---
+    # --- U-SLAM EKFの計算モデル ---
     def state_transition_function(self, x, dt):
+        """状態遷移関数 f(x) - アンカーの位置は変化しない"""
         x_new = np.copy(x)
         theta, v, w = x[2, 0], x[3, 0], x[4, 0]
+        
+        # ロボットの状態のみ更新
         x_new[0] = x[0, 0] + v * dt * np.cos(theta)
         x_new[1] = x[1, 0] + v * dt * np.sin(theta)
         x_new[2] = x[2, 0] + w * dt
+        
+        # アンカーの状態は静的なので変化しない (x_new[5:] = x[5:])
         return x_new
 
     def state_transition_jacobian(self, x, dt):
+        """状態遷移ヤコビ行列 F - アンカーの状態遷移は単位行列"""
+        F = np.eye(self.ekf.dim_x) # まずは単位行列で初期化
         theta, v = x[2, 0], x[3, 0]
-        F = np.eye(5)
+        
+        # ロボットに対応する部分のみを更新
         F[0, 2] = -v * dt * np.sin(theta)
         F[0, 3] = dt * np.cos(theta)
         F[1, 2] = v * dt * np.cos(theta)
@@ -107,17 +124,33 @@ class UwbEkfNode(Node):
         F[2, 4] = dt
         return F
 
-    def h_uwb(self, x, anchor_pos):
-        dx = x[0, 0] - anchor_pos[0]
-        dy = x[1, 0] - anchor_pos[1]
-        return np.array([[np.sqrt(dx**2 + dy**2)]])
+    def h_uslam(self, x, anchor_index):
+        """測定関数 h(x) - ロボットと指定アンカー間の距離"""
+        robot_pos = x[0:2]
+        anchor_start_idx = self.ROBOT_STATE_DIM + anchor_index * self.ANCHOR_STATE_DIM
+        anchor_pos = x[anchor_start_idx : anchor_start_idx + self.ANCHOR_STATE_DIM]
+        
+        return np.array([[np.linalg.norm(robot_pos - anchor_pos)]])
 
-    def H_uwb(self, x, anchor_pos):
-        dx = x[0, 0] - anchor_pos[0]
-        dy = x[1, 0] - anchor_pos[1]
-        dist = np.sqrt(dx**2 + dy**2)
-        if dist < 1e-6: return np.zeros((1, 5))
-        H = np.zeros((1, 5)); H[0, 0] = dx / dist; H[0, 1] = dy / dist
+    def H_uslam(self, x, anchor_index):
+        """測定ヤコビ行列 H - h(x)を状態ベクトルxで偏微分"""
+        H = np.zeros((1, self.ekf.dim_x))
+        robot_pos = x[0:2].flatten()
+        anchor_start_idx = self.ROBOT_STATE_DIM + anchor_index * self.ANCHOR_STATE_DIM
+        anchor_pos = x[anchor_start_idx : anchor_start_idx + self.ANCHOR_STATE_DIM].flatten()
+        
+        delta = robot_pos - anchor_pos
+        dist = np.linalg.norm(delta)
+        if dist < 1e-6: return H
+
+        # ロボット位置(x, y)に関する偏微分
+        H[0, 0] = delta[0] / dist
+        H[0, 1] = delta[1] / dist
+        
+        # 対応するアンカー位置(x, y)に関する偏微分
+        H[0, anchor_start_idx] = -delta[0] / dist
+        H[0, anchor_start_idx + 1] = -delta[1] / dist
+        
         return H
 
     # --- メインループ ---
@@ -125,57 +158,43 @@ class UwbEkfNode(Node):
         current_time = self.get_clock().now()
         dt = (current_time - self.last_time).nanoseconds / 1e9
         self.last_time = current_time
-
-        if dt <= 0:
-            return
+        if dt <= 0: return
 
         # --- 予測(Predict)ステップ ---
         if self.latest_odom:
             self.ekf.x[3,0] = self.latest_odom.twist.twist.linear.x
             self.ekf.x[4,0] = self.latest_odom.twist.twist.angular.z
         
-        # ヤコビ行列Fを現在の状態で計算
         F = self.state_transition_jacobian(self.ekf.x, dt)
-        
-        # --- エラー修正箇所 ---
-        # predict()メソッドは線形モデル用のため、非線形モデルの予測は手動で行う
-        # 1. 共分散を予測: P = F @ P @ F.T + Q
         self.ekf.P = F @ self.ekf.P @ F.T + self.ekf.Q
-        # 2. 状態を予測: x = f(x)
         self.ekf.x = self.state_transition_function(self.ekf.x, dt)
 
-        # ---UWBデータをシリアルから読み取り、更新(Update)ステップを実行---
+        # --- 更新(Update)ステップ ---
         anchor_data = self.uwb_reader.read_anchor_data_snapshot(timeout=self.uwb_timeout)
-
         if anchor_data:
             for twr_id_str, data in anchor_data.items():
-                if data: # データがNoneでないか確認
-                    # 'TWR0'から数字の0を抽出
-                    twr_index = int(twr_id_str.replace('TWR', '')) 
+                if data and data['nlos_los'] == 'LOS':
+                    twr_index = int(twr_id_str.replace('TWR', ''))
+                    z = np.array([[data['distance']]])
                     
-                    # nLOSでない場合のみ更新
-                    if data['nlos_los'] == 'LOS':
-                        anchor_id = self.anchor_map.get(twr_index)
-                        if anchor_id:
-                            anchor_pos = self.anchor_positions[anchor_id]
-                            z = np.array([[data['distance']]])
-                            
-                            self.ekf.update(z, HJacobian=self.H_uwb, Hx=self.h_uwb, R=self.R_uwb,
-                                            args=(anchor_pos,), hx_args=(anchor_pos,))
+                    self.ekf.update(z, HJacobian=self.H_uslam, Hx=self.h_uslam, R=self.R_uwb,
+                                    args=(twr_index,), hx_args=(twr_index,))
 
-        # --- 結果の出力 (変更なし) ---
+        # --- 結果の出力 ---
         self.publish_odometry(current_time)
         self.publish_tf(current_time)
         
     def publish_odometry(self, current_time):
+        """EKFの結果（ロボットの状態のみ）をOdometryとして発行"""
         odom_msg = Odometry()
         odom_msg.header.stamp = current_time.to_msg(); odom_msg.header.frame_id = 'map'; odom_msg.child_frame_id = 'base_link'
         x, y, theta = self.ekf.x[0,0], self.ekf.x[1,0], self.ekf.x[2,0]
         odom_msg.pose.pose.position.x = x; odom_msg.pose.pose.position.y = y
         q = quaternion_from_euler(0, 0, theta)
         odom_msg.pose.pose.orientation.x = q[0]; odom_msg.pose.pose.orientation.y = q[1]; odom_msg.pose.pose.orientation.z = q[2]; odom_msg.pose.pose.orientation.w = q[3]
+        # 共分散もロボットの部分だけを抽出
+        P_pose = self.ekf.P[0:3, 0:3]; indices = [0, 1, 5] # x, y, yaw in 6x6 covariance
         odom_msg.pose.covariance = np.zeros(36)
-        P_pose = self.ekf.P[0:3, 0:3]; indices = [0, 1, 5]
         for i, row in enumerate(indices):
             for j, col in enumerate(indices): odom_msg.pose.covariance[row*6 + col] = P_pose[i, j]
         odom_msg.twist.twist.linear.x = self.ekf.x[3, 0]; odom_msg.twist.twist.angular.z = self.ekf.x[4, 0]
@@ -192,7 +211,7 @@ class UwbEkfNode(Node):
 
 def main(args=None):
     rclpy.init(args=args)
-    node = UwbEkfNode()
+    node = UwbSlamEkfNode()
     try:
         rclpy.spin(node)
     except KeyboardInterrupt:


### PR DESCRIPTION
# Description
## 背景 (Background)
このシステムは、ホイールオドメトリとIMUによる**予測(Predict)ステップ**と、UWBセンサーからの距離情報に基づく**補正(Update) ステップ**を繰り返すことで、高精度な自己位置推定を実現する拡張カルマンフィルタ(EKF)を実装しています。

EKFの補正ステップの精度は、利用できるUWBアンカーの数に大きく依存します。複数のアンカーからの距離情報を同時に利用することで、ロボットの位置(x, y)だけでなく、向き(theta)のドリフトも間接的に、より正確に補正することが可能になります。serialandFilter.pyは、この補正ステップに不可欠なUWBデータを提供する重要な役割を担っています。

## 問題点 (The Problem)
現状のserialandFilter.py内のread_anchor_data_snapshot関数には、データ取得ロジックに重大な欠陥がありました。

UWB受信機から送られてくるTWR[n].elevation_angleのデータを一行読み取った直後にbreak命令が実行されていました。これにより、一つのアンカー（例えばTWR0）のデータを完全に受信した瞬間にデータ収集のwhileループが強制的に終了してしまい、まだ受信できていない他のアンカー（TWR1, TWR2）のデータを待たずに処理を終えていました。

この結果、タイムアウト時間内であれば複数のアンカーからデータを受信できる状況にもかかわらず、常に最初の一つのアンカーデータしかEKFに渡されず、他のアンカーはNoneとして報告されていました。これは、EKFが持つ「複数の観測情報から最も確からしい状態を推定する」という能力を著しく低下させる原因となっていました。

TFがbase_linkに接続されており、私が利用しているMegarover Ver3.0ではbase_linkのX軸座標の正の方向が違っていたので、それを修正しました。

## 解決策 (The Solution)
この問題を解決するため、elevation_angleの処理後にあったbreak命令をcontinueに変更しました。

この修正により、whileループは一つのアンカーデータを処理した後も終了せず、指定されたtimeout時間まで待機し続けます。これにより、その時間内に受信した全てのアンカーからのデータを漏れなく収集し、辞書に格納してEKFノードに返すことが可能になります。

## この修正による効果 (Impact)
EKFの精度向上: 常に利用可能な全てのアンカー情報（1つ、2つ、あるいは3つ）をEKFの補正ステップに提供できるようになります。これにより、位置(x, y)および向き(theta)の推定精度と安定性が大幅に向上します。

堅牢性の向上: 一部のアンカーからの電波が途切れた場合でも、残りのアンカーからの情報を最大限に活用して自己位置推定を継続できるようになり、システム全体の堅牢性（ロバストネス）が高まります。

このプルリクエストにより、EKFが本来持つ性能を最大限に引き出すための、データ入力部分のボトルネックが解消されます。